### PR TITLE
fix(): resolve issue with spaces in paths or file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ vaCuBEErpQ9BjQICB9A=
 
 You must remove the BEGIN CERTIFICATE and END CERTIFICATE lines before saving your secret.
 
-You may find this page by clicking on `Settings > Secrets > Actions` on your current repo.
+You may find the secrets page by navigating to `Settings > Secrets > Actions` on your current repo.
 
 ### `folder`
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,36 @@
 # Code sign a file
 
-This action signs `.nupkg` files and files that are supported by `signtool.exe` with a code signing certificate. This action only works on Windows and that means it should run on `windows-latest`.
+This action signs `.nupkg` files and files that are supported by `signtool.exe` with a code signing certificate. This action only works on Windows build agents, and that means it will only run on `windows-2019`, `windows-2022` or `windows-latest`.
 
 ## Inputs
 
 ### `certificate`
 
-**Required** The base64 encoded certificate.
+**Required** The base64 encoded certificate that does not require a password.
+
+This can done one by converting your pfx file to a base64 encoded string with the following command
+
+```
+certutil -encode .\ssCertInfo.pfx .\ssCertInfo.base64.txt
+```
+
+Once you run the command, you will need to ensure that only the base64 data is saved in your secret as seen here (truncated)
+
+```
+-----BEGIN CERTIFICATE-----
+5VYbl04ksEja358dNhGyHscDAiPI07mM9TwzLgvMv+72lHbgOZC57QgTTVOSVIzM
+fqku3P2y4EP4rXa3efxRtV9U0Iedxn0gYz7qHszBUCVnb/nUMtnHNd9HWtzgizpr
+qmi7jMBMup/eOpXKibt7OzGB2zATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEE
+AYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwB0AHIAbwBuAGcAIABDAHIA
+DQEMAQMwDgQIg6csl1GYzT4CAgfQgIIO6AdED63pjLYWhE4khARlh33Mwe2GT7np
+f5ZayfFO6DeLuc9Zczf41sJR94xSLKzDpvQHpWHiNabP8srad2TEzg8XQrSOgN+Q
+vaCuBEErpQ9BjQICB9A=
+-----END CERTIFICATE-----
+```
+
+You must remove the BEGIN CERTIFICATE and END CERTIFICATE lines before saving your secret.
+
+You may find this page by clicking on `Settings > Secrets > Actions` on your current repo.
 
 ### `folder`
 

--- a/index.ts
+++ b/index.ts
@@ -80,7 +80,7 @@ async function downloadNuGet() {
 
 async function signWithSigntool(signtool: string, certificateFileName: string, fileName: string) {
     try {
-        const { stdout } = await asyncExec(`"${signtool}" sign /f ${certificateFileName} /tr ${timestampUrl} /td sha256 /fd sha256 ${fileName}`);
+        const { stdout } = await asyncExec(`"${signtool}" sign /f ${certificateFileName} /tr ${timestampUrl} /td sha256 /fd sha256 "${fileName}"`);
         console.log(stdout);
         return true;
     } catch(err: unknown) {
@@ -96,7 +96,7 @@ async function signNupkg(certificateFileName: string, fileName: string) {
     await downloadNuGet();
 
     try {
-        const { stdout } = await asyncExec(`"${nugetFileName}" sign ${fileName} -CertificatePath ${certificateFileName} -Timestamper ${timestampUrl}`);
+        const { stdout } = await asyncExec(`"${nugetFileName}" sign "${fileName}" -CertificatePath ${certificateFileName} -Timestamper ${timestampUrl}`);
         console.log(stdout);
         return true;
     } catch(err: unknown){
@@ -109,7 +109,7 @@ async function signNupkg(certificateFileName: string, fileName: string) {
 }
 
 async function trySignFile(signtool: string, certificateFileName: string, fileName: string) {
-    console.log(`Signing ${fileName}.`);
+    console.log(`Signing: ${fileName}.`);
     const extension = path.extname(fileName);
     for (let i=0; i< 10; i++) {
         await sleep(i);


### PR DESCRIPTION
This will fix issues with directory or file names that contain spaces for both nuget and codesign