### PR TITLE
feat: No longer requires manually removing the BEGIN CERTIFICATE and END CERTIFICATE lines before saving the secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This can created by converting your pfx file to a base64 encoded string with the
 certutil -encode .\ssCertInfo.pfx .\ssCertInfo.base64.txt
 ```
 
-Once you run the command, you will need to ensure that only the base64 data is saved in your secret as seen here (truncated)
+Once you run the command, you will need to ensure that the data is saved in your secret as seen here
 
 ```
 -----BEGIN CERTIFICATE-----
@@ -27,8 +27,6 @@ f5ZayfFO6DeLuc9Zczf41sJR94xSLKzDpvQHpWHiNabP8srad2TEzg8XQrSOgN+Q
 vaCuBEErpQ9BjQICB9A=
 -----END CERTIFICATE-----
 ```
-
-You must remove the BEGIN CERTIFICATE and END CERTIFICATE lines before saving your secret.
 
 You may find the secrets page by navigating to `Settings > Secrets > Actions` on your current repo.
 

--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,7 @@ function sleep(seconds: number) {
 }
 
 async function createCertificatePfx() {
-    const base64Certificate = core.getInput('certificate', { required: true });
+    const base64Certificate = core.getInput('certificate', { required: true }).replace(/(-+)(BEGIN|END)( CERTIFICATE)(-+)/g, '');
     const certificate = Buffer.from(base64Certificate, 'base64');
     if (certificate.length == 0)
         throw 'certificate value is not set.';


### PR DESCRIPTION
Hello, 

This PR removes the requirement to edit the base64 encoded pfx file content. The implementation runs a regex replacement to remove the `BEGIN CERTIFICATE` and `END CERTIFICATE` lines. This should streamline the secret entry process by a little.

Tested in the forked repo's action and updated the README as well.